### PR TITLE
New state interface

### DIFF
--- a/src/SparseStates.jl
+++ b/src/SparseStates.jl
@@ -3,7 +3,7 @@ module SparseStates
 using LinearAlgebra
 
 export SparseState
-export num_qubits, setsorted!, expectation
+export num_qubits, expectation
 export AbstractOperator, Operator, SuperOperator, AdjointOperator
 export @operator, @super_operator
 export support, apply, apply!

--- a/src/SparseStates.jl
+++ b/src/SparseStates.jl
@@ -3,7 +3,7 @@ module SparseStates
 using LinearAlgebra
 
 export SparseState
-export num_qubits, expectation
+export num_qubits, setsorted!, expectation
 export AbstractOperator, Operator, SuperOperator, AdjointOperator
 export @operator, @super_operator
 export support, apply, apply!

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -149,7 +149,7 @@ end
 
 function apply!(gate::AdjointOperator{<:U}, state::SparseState; kwargs...)
     (; θ, ϕ, λ) = parent(gate)
-    return apply!(U(support(gate); θ=-θ, ϕ=-λ, λ=-ϕ), state; kwargs...)
+    return apply!(U(support(gate); θ=(-θ), ϕ=(-λ), λ=(-ϕ)), state; kwargs...)
 end
 
 function apply!(gate::RX, state::SparseState; kwargs...)
@@ -159,7 +159,7 @@ end
 
 function apply!(gate::AdjointOperator{<:RX}, state::SparseState; kwargs...)
     (; θ) = parent(gate)
-    return apply!(RX(support(gate); θ=-θ), state; kwargs...)
+    return apply!(RX(support(gate); θ=(-θ)), state; kwargs...)
 end
 
 function apply!(gate::RY, state::SparseState; kwargs...)
@@ -169,7 +169,7 @@ end
 
 function apply!(gate::AdjointOperator{<:RY}, state::SparseState; kwargs...)
     (; θ) = parent(gate)
-    return apply!(RY(support(gate); θ=-θ), state; kwargs...)
+    return apply!(RY(support(gate); θ=(-θ)), state; kwargs...)
 end
 
 function apply!(gate::RZ, state::SparseState; kwargs...)
@@ -186,7 +186,7 @@ end
 
 function apply!(gate::AdjointOperator{<:RZ}, state::SparseState; kwargs...)
     (; θ) = parent(gate)
-    return apply!(RZ(support(gate); θ=-θ), state; kwargs...)
+    return apply!(RZ(support(gate); θ=(-θ)), state; kwargs...)
 end
 
 function apply!(gate::CX, state::SparseState; kwargs...)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -48,7 +48,7 @@ function apply!(gate::X, state::SparseState; kwargs...)
         s, v = table[n]
         table[n] = s ⊻ m => v
     end
-    state.issorted = false
+    setsorted!(state, false)
     return state
 end
 
@@ -60,7 +60,7 @@ function apply!(gate::Y, state::SparseState; kwargs...)
         s, v = table[n]
         table[n] = s ⊻ m => z * conditional_minus(parity(s & m)) * v
     end
-    state.issorted = false
+    setsorted!(state, false)
     return state
 end
 
@@ -99,8 +99,9 @@ function apply!(gate::Union{T,AdjointOperator{T}}, state::SparseState; kwargs...
 end
 
 function apply!(gate::H, state::SparseState; droptol=default_droptol(keytype(state)), kwargs...)
+    # Sort the initial table and set its `refsorted` to `true`
+    sort!(state)
     (; table, masks) = state
-    state.issorted || sort!(table; by=first)
     # Precompute the normalization factor
     z = convert(valtype(state), 1 / √2)
     for (i,) in support(gate)
@@ -117,13 +118,13 @@ function apply!(gate::H, state::SparseState; droptol=default_droptol(keytype(sta
         sort!(new_table; by=first)
         sorted_merge!(table, new_table; droptol)
     end
-    state.issorted = true
     return state
 end
 
 function apply!(gate::U, state::SparseState; droptol=default_droptol(valtype(state)), kwargs...)
+    # Sort the initial table and set its `refsorted` to `true`
+    sort!(state)
     (; table, masks) = state
-    state.issorted || sort!(table; by=first)
     # Precompute the different factors for the gate to be in the form `[α -β'; β α']`
     (; θ, ϕ, λ) = gate
     a, b = cis(-ϕ / 2), cis(-λ / 2)
@@ -143,7 +144,6 @@ function apply!(gate::U, state::SparseState; droptol=default_droptol(valtype(sta
         sort!(new_table; by=first)
         sorted_merge!(table, new_table; droptol)
     end
-    state.issorted = true
     return state
 end
 
@@ -199,7 +199,7 @@ function apply!(gate::CX, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
-    state.issorted = false
+    setsorted!(state, false)
     return state
 end
 
@@ -216,7 +216,7 @@ function apply!(gate::CY, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
-    state.issorted = false
+    setsorted!(state, false)
     return state
 end
 
@@ -248,7 +248,7 @@ function apply!(gate::SWAP, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
-    state.issorted = false
+    setsorted!(state, false)
     return state
 end
 
@@ -262,7 +262,7 @@ function apply!(gate::CCX, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
-    state.issorted = false
+    setsorted!(state, false)
     return state
 end
 
@@ -279,7 +279,7 @@ function apply!(gate::CCY, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
-    state.issorted = false
+    setsorted!(state, false)
     return state
 end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -48,6 +48,7 @@ function apply!(gate::X, state::SparseState; kwargs...)
         s, v = table[n]
         table[n] = s ⊻ m => v
     end
+    state.issorted = false
     return state
 end
 
@@ -59,6 +60,7 @@ function apply!(gate::Y, state::SparseState; kwargs...)
         s, v = table[n]
         table[n] = s ⊻ m => z * conditional_minus(parity(s & m)) * v
     end
+    state.issorted = false
     return state
 end
 
@@ -98,7 +100,7 @@ end
 
 function apply!(gate::H, state::SparseState; droptol=default_droptol(keytype(state)), kwargs...)
     (; table, masks) = state
-    sort!(table; by=first)
+    state.issorted || sort!(table; by=first)
     # Precompute the normalization factor
     z = convert(valtype(state), 1 / √2)
     for (i,) in support(gate)
@@ -115,12 +117,13 @@ function apply!(gate::H, state::SparseState; droptol=default_droptol(keytype(sta
         sort!(new_table; by=first)
         sorted_merge!(table, new_table; droptol)
     end
+    state.issorted = true
     return state
 end
 
 function apply!(gate::U, state::SparseState; droptol=default_droptol(valtype(state)), kwargs...)
     (; table, masks) = state
-    sort!(table; by=first)
+    state.issorted || sort!(table; by=first)
     # Precompute the different factors for the gate to be in the form `[α -β'; β α']`
     (; θ, ϕ, λ) = gate
     a, b = cis(-ϕ / 2), cis(-λ / 2)
@@ -140,6 +143,7 @@ function apply!(gate::U, state::SparseState; droptol=default_droptol(valtype(sta
         sort!(new_table; by=first)
         sorted_merge!(table, new_table; droptol)
     end
+    state.issorted = true
     return state
 end
 
@@ -195,6 +199,7 @@ function apply!(gate::CX, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
+    state.issorted = false
     return state
 end
 
@@ -211,6 +216,7 @@ function apply!(gate::CY, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
+    state.issorted = false
     return state
 end
 
@@ -242,6 +248,7 @@ function apply!(gate::SWAP, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
+    state.issorted = false
     return state
 end
 
@@ -255,6 +262,7 @@ function apply!(gate::CCX, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
+    state.issorted = false
     return state
 end
 
@@ -271,6 +279,7 @@ function apply!(gate::CCY, state::SparseState; kwargs...)
             table[n] = s => v
         end
     end
+    state.issorted = false
     return state
 end
 

--- a/src/states.jl
+++ b/src/states.jl
@@ -50,7 +50,7 @@ SparseState(qubits::Int) = SparseState{DEFAULT_KEYTYPE}(qubits)
 num_qubits(state::SparseState) = length(state.masks)
 
 Base.length(state::SparseState) = length(state.table)
-Base.empty(state::SparseState, K, V) = SparseState{K,V}([], state.masks, true)
+Base.empty(state::SparseState{K,V}) where {K,V} = SparseState{K,V}([], state.masks, RefValue(true))
 Base.copy(state::SparseState) = SparseState(copy(state.table), copy(state.masks), Ref(state.refsorted[]))
 Base.sizehint!(state::SparseState, n::Integer) = sizehint!(state.table, n)
 Base.iterate(state::SparseState, args...) = iterate(state.table, args...)

--- a/src/states.jl
+++ b/src/states.jl
@@ -1,3 +1,5 @@
+using Base: RefValue
+
 const DEFAULT_KEYTYPE = UInt64
 const DEFAULT_ELTYPE = Complex{Float64}
 
@@ -21,7 +23,7 @@ end
 struct SparseState{K,V} <: AbstractDict{K,V}
     table::Vector{Pair{K,V}}
     masks::Vector{K}
-    refsorted::Ref{Bool}
+    refsorted::RefValue{Bool}
 end
 
 function SparseState{K,V}(pairs, qubits::Int) where {K,V}

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -51,6 +51,7 @@ function apply!(channel::Reset, state::SparseState{K,V}) where {K,V}
         return outcome
     end
     callback(outcomes, state)
+    state.issorted = false
     return state
 end
 
@@ -90,6 +91,7 @@ function apply!(channel::MeasureOperator, state::SparseState)
         return outcome
     end
     callback(outcomes, state)
+    state.issorted = true
     return state
 end
 

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -50,8 +50,8 @@ function apply!(channel::Reset, state::SparseState{K,V}) where {K,V}
         end
         return outcome
     end
+    setsorted!(state, false)
     callback(outcomes, state)
-    state.issorted = false
     return state
 end
 
@@ -91,7 +91,6 @@ function apply!(channel::MeasureOperator, state::SparseState)
         return outcome
     end
     callback(outcomes, state)
-    state.issorted = true
     return state
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ const VAL_TYPES = (REAL_VAL_TYPES..., COMPLEX_VAL_TYPES...)
         @test issorted(state) && state["01"] ≈ 0 && state["11"] ≈ 0
         @test (@inferred dot(state, state)) ≈ 1
         @test (@inferred norm(state)) ≈ 1
+        @test norm(empty(state)) ≈ 0
 
         state_first = SparseState{K,V}("01" => 1, 2)
         state_second = SparseState{K,V}("001" => 1, 3)
@@ -45,6 +46,7 @@ const VAL_TYPES = (REAL_VAL_TYPES..., COMPLEX_VAL_TYPES...)
         @test num_qubits(state_prod) == 2 + 3
         @test length(state_prod) == 1
         @test state_prod["01001"] ≈ 1
+        @test kron(state_first, state_second, state_first) == kron(kron(state_first, state_second), state_first)
 
         state = SparseState{K,V}(["00" => 1, "01" => 1, "10" => 1, "11" => 1], 2)
         @test norm(state) ≈ 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,10 +25,14 @@ const VAL_TYPES = (REAL_VAL_TYPES..., COMPLEX_VAL_TYPES...)
         @test (@inferred state["00"]) ≈ 1
         @test_throws ArgumentError state["000"]
         @test_throws ArgumentError state["02"]
+        @test_throws KeyError state["01"]
         get!(state, "01", 1 // 2)
         @test issorted(state) && state["01"] ≈ 0.5
+        get!(state, "01", 0)
+        @test issorted(state) && state["01"] ≈ 0.5
         state["01"] = 0
-        @test issorted(state) && state["01"] ≈ 0
+        state["11"] = 0
+        @test issorted(state) && state["01"] ≈ 0 && state["11"] ≈ 0
         @test (@inferred dot(state, state)) ≈ 1
         @test (@inferred norm(state)) ≈ 1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ const VAL_TYPES = (REAL_VAL_TYPES..., COMPLEX_VAL_TYPES...)
         @test state isa AbstractDict
         @test (@inferred keytype(state)) == K && (@inferred valtype(state)) == V
         @test (@inferred num_qubits(state)) == 2
+        @test (@inferred issorted(state))
         @test (@inferred length(state)) == 1
         @test (@inferred haskey(state, 0))
         @test (@inferred haskey(state, "00"))
@@ -24,9 +25,12 @@ const VAL_TYPES = (REAL_VAL_TYPES..., COMPLEX_VAL_TYPES...)
         @test (@inferred state["00"]) ≈ 1
         @test_throws ArgumentError state["000"]
         @test_throws ArgumentError state["02"]
-
-        @test dot(state, state) ≈ 1
-        @test norm(state) ≈ 1
+        get!(state, "01", 1 // 2)
+        @test issorted(state) && state["01"] ≈ 0.5
+        state["01"] = 0
+        @test issorted(state) && state["01"] ≈ 0
+        @test (@inferred dot(state, state)) ≈ 1
+        @test (@inferred norm(state)) ≈ 1
 
         state_first = SparseState{K,V}("01" => 1, 2)
         state_second = SparseState{K,V}("001" => 1, 3)


### PR DESCRIPTION
This PR introduces a mutable boolean field to flag the fact that a `SparseState` is sorted or not. Sortedness is useful in certain cases, such as speeding up `LinearAlgebra.dot`. So now `sort!` is by default lazy, and will first check if this flag is set.

Implementations of new operators are responsible for changing this flag in the case that the order of the basis states stored is changed.
