### PR TITLE
Implement callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SparseStates.jl
 
+**⚠️ This is still experimental. It is not stable. It is not polished. ⚠️**
 
 This package efficiently simulates quantum circuits that don't generate a lot of superposition in the computational basis.
 In other words, they are few basis states to keep track of.

--- a/src/SparseStates.jl
+++ b/src/SparseStates.jl
@@ -8,8 +8,9 @@ export AbstractOperator, Operator, SuperOperator, AdjointOperator
 export @operator, @super_operator
 export support, apply, apply!
 export X, Y, Z, H, S, T, U, RX, RY, RZ, CX, CNOT, CY, CZ, SWAP, CCX, CCNOT, CCY, CCZ
-export Reset, Measure, MeasureOperator, DepolarizingChannel
 export Circuit
+export Reset, Measure, MeasureOperator, DepolarizingChannel
+export Register, Feedback
 export pauli_combinations, pauli_strings
 export pauli_decomposition, append_operators, drop_error_operators, error_locations, insert_error_operators
 
@@ -18,6 +19,7 @@ include("abstractoperators.jl")
 include("operators.jl")
 include("circuits.jl")
 include("superoperators.jl")
+include("callbacks.jl")
 include("utils.jl")
 
 end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -28,7 +28,6 @@ Base.firstindex(register::Register) = firstindex(parent(register))
 Base.lastindex(register::Register) = lastindex(parent(register))
 Base.getindex(register::Register, i) = getindex(parent(register), i)
 
-
 function Base.show(io::IO, register::Register)
     return print(io, "Register($(register.tape))")
 end
@@ -54,7 +53,7 @@ end
 function Base.show(io::IO, feedback::Feedback)
     print(io, "Feedback", "(")
     print(io, (feedback.trigger == identity) ? "" : "$(feedback.trigger), ")
-    print(io, (length(feedback.ops) == 1) ? only(feedback.ops) : ops)
+    print(io, (length(feedback.ops) == 1) ? only(feedback.ops) : feedback.ops)
     print(io, ")")
     return nothing
 end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,0 +1,60 @@
+abstract type AbstractCallback end
+
+struct Register <: AbstractCallback
+    tape::BitVector
+end
+
+function Register(; sizehint::Int=-1)
+    tape = BitVector()
+    sizehint > 0 && sizehint!(tape, sizehint)
+    return Register(tape)
+end
+
+function (register::Register)(outcomes::AbstractVector{Bool}, state::SparseState)
+    append!(register.tape, outcomes)
+    return nothing
+end
+
+Base.parent(register::Register) = register.tape
+Base.BitVector(register::Register) = parent(register)
+Base.Vector(register::Register) = Vector(parent(register))
+Base.collect(register::Register) = Vector(register)
+Base.empty!(register::Register) = empty!(parent(register))
+
+# Iterator interface
+Base.length(register::Register) = length(parent(register))
+Base.iterate(register::Register, args...) = iterate(parent(register), args...)
+Base.firstindex(register::Register) = firstindex(parent(register))
+Base.lastindex(register::Register) = lastindex(parent(register))
+Base.getindex(register::Register, i) = getindex(parent(register), i)
+
+
+function Base.show(io::IO, register::Register)
+    return print(io, "Register($(register.tape))")
+end
+
+struct Feedback{F<:Function,T<:Tuple} <: AbstractCallback
+    trigger::F
+    ops::T
+end
+
+Feedback(trigger::Function, op::AbstractOperator) = Feedback(trigger, (op,))
+Feedback(ops::Tuple) = Feedback(identity, ops)
+Feedback(ops::AbstractOperator...) = Feedback(ops)
+
+function (feedback::Feedback)(outcomes::AbstractVector{Bool}, state::SparseState)
+    (; trigger, ops) = feedback
+    values = trigger(outcomes)
+    for (value, op) in zip(values, ops)
+        value && apply!(op, state)
+    end
+    return nothing
+end
+
+function Base.show(io::IO, feedback::Feedback)
+    print(io, "Feedback", "(")
+    print(io, (feedback.trigger == identity) ? "" : "$(feedback.trigger), ")
+    print(io, (length(feedback.ops) == 1) ? only(feedback.ops) : ops)
+    print(io, ")")
+    return nothing
+end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -32,14 +32,13 @@ function Base.show(io::IO, register::Register)
     return print(io, "Register($(register.tape))")
 end
 
-struct Feedback{F<:Function,T<:Tuple} <: AbstractCallback
+struct Feedback{F<:Function,V<:AbstractVector} <: AbstractCallback
     trigger::F
-    ops::T
+    ops::V
 end
 
-Feedback(trigger::Function, op::AbstractOperator) = Feedback(trigger, (op,))
-Feedback(ops::Tuple) = Feedback(identity, ops)
-Feedback(ops::AbstractOperator...) = Feedback(ops)
+Feedback(trigger::Function, op::AbstractOperator) = Feedback(trigger, [op])
+Feedback(ops::AbstractOperator...) = Feedback(identity, collect(ops))
 
 function (feedback::Feedback)(outcomes::AbstractVector{Bool}, state::SparseState)
     (; trigger, ops) = feedback

--- a/src/superoperators.jl
+++ b/src/superoperators.jl
@@ -3,8 +3,8 @@ const PAULI_COMBINATIONS = ntuple(l -> collect(pauli_combinations(l)), 3)
 
 default_callback(outcomes, state::SparseState) = nothing
 
-@super_operator Reset{F<:Function} 1 callback::F = default_callback
-@super_operator Measure{F<:Function} 1 callback::F = default_callback
+@super_operator Reset{F} 1 callback::F = default_callback
+@super_operator Measure{F} 1 callback::F = default_callback
 
 function apply!(channel::Measure, state::SparseState{K,V}) where {K,V}
     (; callback) = channel
@@ -55,12 +55,12 @@ function apply!(channel::Reset, state::SparseState{K,V}) where {K,V}
     return state
 end
 
-struct MeasureOperator{O<:AbstractOperator,F<:Function} <: SuperOperator
+struct MeasureOperator{O<:AbstractOperator,F} <: SuperOperator
     ops::Vector{O}
     callback::F
 end
 
-function MeasureOperator(ops::AbstractArray{O}; callback::F=default_callback) where {O<:AbstractOperator,F<:Function}
+function MeasureOperator(ops::AbstractArray{O}; callback::F=default_callback) where {O<:AbstractOperator,F}
     return MeasureOperator(vec(collect(ops)), callback)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -389,7 +389,7 @@ end
     table[[0, 0, 0]] = zeros(Bool, 7)
     lookup = out -> table[out]
 
-    corrections = Dict(X => ntuple(i -> X(i), 7), Z => ntuple(i -> Z(i), 7))
+    corrections = Dict(X => map(X, 1:7), Z => map(Z, 1:7))
 
     # Unitary encoding circuit
     circuit_zero = Circuit(


### PR DESCRIPTION
This PR adds some convenience structures to perform common operations during measurements, including:
- `Register` saves measurement outcomes to a classical register;
- `Feedback` applies some operators conditional to some specified logic using the measurement outcomes.